### PR TITLE
refactor: remove unused luci.model.network from groundrouting

### DIFF
--- a/packages/ubus-lime-groundrouting/Makefile
+++ b/packages/ubus-lime-groundrouting/Makefile
@@ -6,7 +6,7 @@ define Package/$(PKG_NAME)
   MAINTAINER:=Marcos Gutierrez <gmarcos87@gmail.com>
   SUBMENU:=3. Applications
   TITLE:=Libremap ubus ground routing module
-  DEPENDS:= +lua +libubox-lua +libubus-lua +libuci-lua +lime-system +luci-lib-jsonc +luci-compat
+  DEPENDS:= +lua +libubox-lua +libubus-lua +libuci-lua +lime-system +luci-lib-jsonc
   PKGARCH:=all
 endef
 

--- a/packages/ubus-lime-groundrouting/files/usr/libexec/rpcd/lime-groundrouting
+++ b/packages/ubus-lime-groundrouting/files/usr/libexec/rpcd/lime-groundrouting
@@ -7,7 +7,6 @@ require "ubus"
 local json = require 'luci.jsonc'
 local config = require 'lime.config'
 local network = require 'lime.network'
-local ntm = require "luci.model.network".init()
 local libuci = require "uci"
 
 local function shell(command)


### PR DESCRIPTION
I am unfamiliar with the functionality of the groundrouting package, but when analyzing possibilities for slimming down the bundle, we found that some dependencies could be removed.
The unit tests pass. And we test it on real hardware.
How could I verify that this change does not introduce any issues?

files/usr/libexec/rpcd/lime-groundrouting: remove unused ntm variable
Makefile: remove luci-compat dependency

The luci.model.network module was imported but never used (ntm variable defined but not referenced). This dependency pulled in luci-base and luci-lua-runtime unnecessarily.

Standalone luci-lib-jsonc (already in lime-system deps) is sufficient.

